### PR TITLE
removed book title on home page

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -6,14 +6,13 @@
       </div>
     <!--<div class= "background-fuzz"> -->
       <blockquote><span class= "early">Whereas the body can disappear</span><br/>
-        into information with scarcely a murmur of protest, embodiment cannot, 
+        into information with scarcely a murmur of protest, embodiment cannot,
         for it is tied to the circumstances of the occasion and the person.”
       </blockquote>
       <div class="container">
         <div class="row home-row">
         <div class="under-shape-one"></div>
-          <p><span class= "early">How We Became Posthuman:</span><br/>
-            Virtual Bodies in Cybernetics, Literature, and Informatics Katherine Hayles
+          <p><span class= "early">Katherine Hayles</span><br/>
           </p>
         <div class="under-shape-two"></div>
         </div><!-- class row -->


### PR DESCRIPTION
this is a test pull request. I changed the copy in the title page to remove the book title.